### PR TITLE
feat: update-config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,8 +6,10 @@ FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim-bookworm
 
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
+  export DEBIAN_FRONTEND=noninteractive && \
   apt-get install --no-install-recommends -y apt-utils build-essential curl git libpq-dev libvips node-gyp pkg-config python-is-python3 \
   iproute2 openssh-client postgresql-client vim libjemalloc2 gnupg2 direnv fzy \
+  firefox-esr \
   && apt-get clean
 
 # Install JavaScript dependencies

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,7 @@
   "service": "app",
   "workspaceFolder": "/workspace",
   "remoteEnv": {
-    "PATH": "/workspace/bin:${containerEnv:PATH}",
-    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
-    "GITHUB_USER": "${localEnv:GITHUB_USER}"
+    "PATH": "/workspace/bin:${containerEnv:PATH}"
   },
   "customizations": {
     "vscode": {
@@ -23,22 +21,26 @@
         "ninoseki.vscode-mogami",
         "esbenp.prettier-vscode",
         "dbaeumer.vscode-eslint",
-        "mhutchie.git-graph"
+        "mhutchie.git-graph",
+        "connorshea.vscode-ruby-test-adapter",
+        "MateuszDrewniak.ruby-test-runner",
+        "davidpallinder.rails-test-runner",
+        "oderwat.indent-rainbow"
       ]
     }
   },
   "features": {
-    "ghcr.io/devcontainers/features/common-utils:2": {
-      "installZsh": true,
-      "configureZshAsDefaultShell": true,
-      "installOhMyZsh": false,
-      "installOhMyZshConfig": false,
-      "upgradePackages": true
-    }
+    "ghcr.io/devcontainers/features/common-utils:2": {},
+    "ghcr.io/devcontainers/features/desktop-lite:1": {}
   },
   "forwardPorts": [
     3000,
-    3306,
-    1080
-  ]
+    5432,
+    6080
+  ],
+  "portsAttributes": {
+    "6080": {
+      "label": "desktop"
+    }
+  }
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,24 @@
       "type": "rdbg",
       "name": "Attach with rdbg",
       "request": "attach"
+    },
+    {
+      "type": "rdbg",
+      "name": "Debug test file with rdbg",
+      "request": "launch",
+      "script": "${env:GEM_HOME}/bin/rspec",
+      "args": [
+        "${file}"
+      ]
+    },
+    {
+      "type": "rdbg",
+      "name": "Debug test at line with rdbg",
+      "request": "launch",
+      "script": "${env:GEM_HOME}/bin/rspec",
+      "args": [
+        "${file}:${lineNumber}"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds:

- desktop-lite for browser support via VNC
- firefox browser as the browser that can be accessed via VNC
- additional debugging tasks for RSpec in launcher settings